### PR TITLE
ドキュメントのtypoを修正

### DIFF
--- a/docs/_docs/References/k-label.md
+++ b/docs/_docs/References/k-label.md
@@ -19,7 +19,7 @@ demo: k-label
 </template>
 ```
 
-## Attreibute
+## Attribute
 
 | Name            | Description                                                      | Type    | Required |
 | --------------- | ---------------------------------------------------------------- | ------- | -------- |

--- a/docs/_docs/References/k-spinner.md
+++ b/docs/_docs/References/k-spinner.md
@@ -20,7 +20,7 @@ demo: k-spinner
 </template>
 ```
 
-## Attreibute
+## Attribute
 
 | Name    | Description                                                           | Type    | Required |
 | ------- | --------------------------------------------------------------------- | ------- | -------- |

--- a/docs/_docs/References/k-table.md
+++ b/docs/_docs/References/k-table.md
@@ -92,7 +92,7 @@ export default {
 </script>
 ```
 
-## Attreibute
+## Attribute
 
 | Name               | Description                                       | Type                | Required |
 | ------------------ | ------------------------------------------------- | ------------------- | -------- |

--- a/docs/_docs/References/k-text-button.md
+++ b/docs/_docs/References/k-text-button.md
@@ -28,7 +28,7 @@ export default {
 </script>
 ```
 
-## Attreibute
+## Attribute
 
 | Name | Description                       | Type   | Required |
 | ---- | --------------------------------- | ------ | -------- |

--- a/docs/_docs/References/k-text.md
+++ b/docs/_docs/References/k-text.md
@@ -28,7 +28,7 @@ export default {
 </script>
 ```
 
-## Attreibute
+## Attribute
 
 | Name        | Description                                                          | Type    | Required |
 | ----------- | -------------------------------------------------------------------- | ------- | -------- |


### PR DESCRIPTION
`kintone-vue-component`、すごく便利で自分が作った[Kintoneプラグイン](https://github.com/alice1017/kintone-record-color-plugin)にも使用させて頂いております。ドキュメントを読んでいてtypoを発見したのでプルリク出させて頂きました。
